### PR TITLE
Remove anyhow from dependencies

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,3 +49,4 @@ These contributors could not be identified by any legal name:
 "toasteater" (github.com/toasteater)
 "cetra3" (github.com/cetra3)
 "masinc" (github.com/masinc)
+"Mingun" (github.com/Mingun)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = "1.0.195"
 unsafe-libyaml = "0.2.11"
 
 [dev-dependencies]
-anyhow = "1.0.79"
 indoc = "2.0"
 serde_derive = "1.0.195"
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -24,13 +24,12 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Deserializing a single document:
 ///
 /// ```
-/// use anyhow::Result;
 /// use serde::Deserialize;
-/// use serde_yaml_ng::Value;
+/// use serde_yaml_ng::{Deserializer, Result, Value};
 ///
 /// fn main() -> Result<()> {
 ///     let input = "k: 107\n";
-///     let de = serde_yaml_ng::Deserializer::from_str(input);
+///     let de = Deserializer::from_str(input);
 ///     let value = Value::deserialize(de)?;
 ///     println!("{:?}", value);
 ///     Ok(())
@@ -40,14 +39,13 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Deserializing multi-doc YAML:
 ///
 /// ```
-/// use anyhow::Result;
 /// use serde::Deserialize;
-/// use serde_yaml_ng::Value;
+/// use serde_yaml_ng::{Deserializer, Result, Value};
 ///
 /// fn main() -> Result<()> {
 ///     let input = "---\nk: 107\n...\n---\nj: 106\n";
 ///
-///     for document in serde_yaml_ng::Deserializer::from_str(input) {
+///     for document in Deserializer::from_str(input) {
 ///         let value = Value::deserialize(document)?;
 ///         println!("{:?}", value);
 ///     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -22,13 +22,13 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// # Example
 ///
 /// ```
-/// use anyhow::Result;
 /// use serde::Serialize;
 /// use std::collections::BTreeMap;
+/// use serde_yaml_ng::{Result, Serializer};
 ///
 /// fn main() -> Result<()> {
 ///     let mut buffer = Vec::new();
-///     let mut ser = serde_yaml_ng::Serializer::new(&mut buffer);
+///     let mut ser = Serializer::new(&mut buffer);
 ///
 ///     let mut object = BTreeMap::new();
 ///     object.insert("k", 107);


### PR DESCRIPTION
It is used only in two doc test examples where the concrete type of `Result` does not matter. I think, it is better to not bloat developer's dependencies with unnecessary crates that increases cognitive load and compilation times.