### PR TITLE
Do not unnecessary clone owned Cow when creating `Value` from `Cow<str>`

### DIFF
--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -92,7 +92,7 @@ impl<'a> From<Cow<'a, str>> for Value {
     /// let x: Value = s.into();
     /// ```
     fn from(f: Cow<'a, str>) -> Self {
-        Value::String(f.to_string())
+        Value::String(f.into_owned())
     }
 }
 


### PR DESCRIPTION
`Cow::to_string` takes `&self` and will clone already owned string, but then original cow will be dropped in `From<Cow>::from` implementation. This PR takes content out from Cow using into_owned which is no-op for owned Cows.