### PR TITLE
fix: partial support flatten enum in struct

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1272,7 +1272,11 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
         // Robust impl blocked on https://github.com/serde-rs/serde/pull/2420
         let is_serde_content = {
             let name = std::any::type_name::<V::Value>();
-            name.starts_with("serde::") && name.ends_with("::de::Content")
+            // serde < 1.0.228: "serde::__private::de::Content"
+            // serde >= 1.0.228: "serde_core::private::content::Content<'_>"
+            name.starts_with("serde")
+                && (name.ends_with("::de::Content")
+                    || name.contains("::content::Content"))
         };
 
         let old_serde_content_newtype = mem::replace(&mut self.is_serde_content_newtype, false);

--- a/src/de.rs
+++ b/src/de.rs
@@ -800,18 +800,18 @@ impl<'de> de::MapAccess<'de> for EnumAccess<'de, '_, '_> {
     where
         V: DeserializeSeed<'de>,
     {
-        let mut de = DeserializerFromEvents {  
-            document: self.de.document,  
-            pos: self.de.pos,  
-            jumpcount: self.de.jumpcount,  
-            path: self.de.path,  
-            remaining_depth: self.de.remaining_depth,  
-            current_enum: Some(CurrentEnum {  
-                name: self.name,  
-                tag: self.tag,  
-            }),  
-            is_serde_content_newtype: true,  
-        };  
+        let mut de = DeserializerFromEvents {
+            document: self.de.document,
+            pos: self.de.pos,
+            jumpcount: self.de.jumpcount,
+            path: self.de.path,
+            remaining_depth: self.de.remaining_depth,
+            current_enum: Some(CurrentEnum {
+                name: self.name,
+                tag: self.tag,
+            }),
+            is_serde_content_newtype: true,
+        };
         seed.deserialize(&mut de)
     }
 }
@@ -1270,8 +1270,10 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
         }
         // TODO: switch to JSON enum semantics for JSON content
         // Robust impl blocked on https://github.com/serde-rs/serde/pull/2420
-        let is_serde_content =
-            std::any::type_name::<V::Value>() == std::any::type_name::<serde::__private::de::Content>();
+        let is_serde_content = {
+            let name = std::any::type_name::<V::Value>();
+            name.starts_with("serde::") && name.ends_with("::de::Content")
+        };
 
         let old_serde_content_newtype = mem::replace(&mut self.is_serde_content_newtype, false);
         loop {

--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -17,30 +17,32 @@ pub(crate) struct Error {
 
 impl Error {
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
+        let p = unsafe { &(*parser) };
         Error {
-            kind: unsafe { (*parser).error },
-            problem: match NonNull::new(unsafe { (*parser).problem as *mut _ }) {
+            kind: p.error,
+            problem: match NonNull::new(p.problem.cast_mut()) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => CStr::from_bytes_with_nul(b"libyaml parser failed but there is no error\0"),
             },
-            problem_offset: unsafe { (*parser).problem_offset },
+            problem_offset: p.problem_offset,
             problem_mark: Mark {
-                sys: unsafe { (*parser).problem_mark },
+                sys: p.problem_mark,
             },
-            context: match NonNull::new(unsafe { (*parser).context as *mut _ }) {
+            context: match NonNull::new(p.context.cast_mut()) {
                 Some(context) => Some(unsafe { CStr::from_ptr(context) }),
                 None => None,
             },
             context_mark: Mark {
-                sys: unsafe { (*parser).context_mark },
+                sys: p.context_mark,
             },
         }
     }
 
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
+        let e = unsafe { &(*emitter) };
         Error {
-            kind: unsafe { (*emitter).error },
-            problem: match NonNull::new(unsafe { (*emitter).problem as *mut _ }) {
+            kind: e.error,
+            problem: match NonNull::new(e.problem.cast_mut()) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => {
                     CStr::from_bytes_with_nul(b"libyaml emitter failed but there is no error\0")

--- a/src/libyaml/parser.rs
+++ b/src/libyaml/parser.rs
@@ -84,7 +84,7 @@ impl<'input> Parser<'input> {
         let mut event = MaybeUninit::<sys::yaml_event_t>::uninit();
         unsafe {
             let parser = addr_of_mut!((*self.pin.ptr).sys);
-            if (*parser).error != sys::YAML_NO_ERROR {
+            if (&(*parser)).error != sys::YAML_NO_ERROR {
                 return Err(Error::parse_error(parser));
             }
             let event = event.as_mut_ptr();

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -203,8 +203,10 @@ impl<'de> Deserializer<'de> for Value {
     where
         V: Visitor<'de>,
     {
-        let is_serde_value = std::any::type_name::<V::Value>()
-            == std::any::type_name::<serde::__private::de::Content>();
+        let is_serde_value = {
+            let name = std::any::type_name::<V::Value>();
+            name.starts_with("serde::") && name.ends_with("::de::Content")
+        };
         match self {
             Value::Null => visitor.visit_unit(),
             Value::Bool(v) => visitor.visit_bool(v),
@@ -725,8 +727,10 @@ impl<'de> Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        let is_serde_content = std::any::type_name::<V::Value>()
-            == std::any::type_name::<serde::__private::de::Content>();
+        let is_serde_content = {
+            let name = std::any::type_name::<V::Value>();
+            name.starts_with("serde::") && name.ends_with("::de::Content")
+        };
         match self {
             Value::Null => visitor.visit_unit(),
             Value::Bool(v) => visitor.visit_bool(*v),

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -205,7 +205,9 @@ impl<'de> Deserializer<'de> for Value {
     {
         let is_serde_value = {
             let name = std::any::type_name::<V::Value>();
-            name.starts_with("serde::") && name.ends_with("::de::Content")
+            name.starts_with("serde")
+                && (name.ends_with("::de::Content")
+                    || name.contains("::content::Content"))
         };
         match self {
             Value::Null => visitor.visit_unit(),
@@ -729,7 +731,9 @@ impl<'de> Deserializer<'de> for &'de Value {
     {
         let is_serde_content = {
             let name = std::any::type_name::<V::Value>();
-            name.starts_with("serde::") && name.ends_with("::de::Content")
+            name.starts_with("serde")
+                && (name.ends_with("::de::Content")
+                    || name.contains("::content::Content"))
         };
         match self {
             Value::Null => visitor.visit_unit(),


### PR DESCRIPTION
Close #14 

The coding approach is according to https://github.com/ron-rs/ron/pull/451.

The `serde_yaml_ng::from_str::<Outer>(yaml).is_err()` should always failed with `invalid type: unit value, expected a string`, which is blocked by https://github.com/serde-rs/serde/issues/1183