### PR TITLE
Add missing boolean strings.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -927,8 +927,8 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
+        "true" | "True" | "TRUE" | "yes" | "Yes" | "YES" | "y" | "Y" => Some(true),
+        "false" | "False" | "FALSE" | "no" | "No" | "NO" | "n" | "N" => Some(false),
         _ => None,
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -927,8 +927,8 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" | "yes" | "Yes" | "YES" | "y" | "Y" => Some(true),
-        "false" | "False" | "FALSE" | "no" | "No" | "NO" | "n" | "N" => Some(false),
+        "true" | "True" | "TRUE" | "yes" | "Yes" | "YES" | "y" | "Y" | "on" | "On" | "ON" => Some(true),
+        "false" | "False" | "FALSE" | "no" | "No" | "NO" | "n" | "N" | "off" | "Off" | "OFF" => Some(false),
         _ => None,
     }
 }


### PR DESCRIPTION
Before, a deserialized `"No"` would actually be serialized as unquoted `No`. When deserializing that again, the type will mismatch.
