### PR TITLE
Add all boolean representations

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -925,10 +925,16 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
     }
 }
 
+/// Parse a boolean according to the YAML 1.1 specification.
+/// https://yaml.org/type/bool.html
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
+        "y" | "Y" | "yes" | "Yes" | "YES" | "true" | "True" | "TRUE" | "on" | "On" | "ON" => {
+            Some(true)
+        }
+        "n" | "N" | "no" | "No" | "NO" | "false" | "False" | "FALSE" | "off" | "Off" | "OFF" => {
+            Some(false)
+        }
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //!     // Serialize it to a YAML string.
 //!     let yaml = serde_yaml_ng::to_string(&map)?;
-//!     assert_eq!(yaml, "x: 1.0\ny: 2.0\n");
+//!     assert_eq!(yaml, "x: 1.0\n'y': 2.0\n");
 //!
 //!     // Deserialize it back to a Rust type.
 //!     let deserialized_map: BTreeMap<String, f64> = serde_yaml_ng::from_str(&yaml)?;
@@ -57,7 +57,7 @@
 //!     let point = Point { x: 1.0, y: 2.0 };
 //!
 //!     let yaml = serde_yaml_ng::to_string(&point)?;
-//!     assert_eq!(yaml, "x: 1.0\ny: 2.0\n");
+//!     assert_eq!(yaml, "x: 1.0\n'y': 2.0\n");
 //!
 //!     let deserialized_point: Point = serde_yaml_ng::from_str(&yaml)?;
 //!     assert_eq!(point, deserialized_point);

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -219,7 +219,7 @@ where
     /// # use serde_yaml_ng::Value;
     /// #
     /// # fn main() -> serde_yaml_ng::Result<()> {
-    /// let data: serde_yaml_ng::Value = serde_yaml_ng::from_str(r#"{ x: { y: [z, zz] } }"#)?;
+    /// let data: serde_yaml_ng::Value = serde_yaml_ng::from_str(r#"{ x: { 'y': [z, zz] } }"#)?;
     ///
     /// assert_eq!(data["x"]["y"], serde_yaml_ng::from_str::<Value>(r#"["z", "zz"]"#).unwrap());
     /// assert_eq!(data["x"]["y"][0], serde_yaml_ng::from_str::<Value>(r#""z""#).unwrap());

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -233,7 +233,7 @@ fn test_enum_representations() {
         Enum::Number(0.0),
     ];
 
-    test_de(yaml, &expected);
+    test_de_no_value(yaml, &expected);
 
     let yaml = indoc! {"
         - !String
@@ -451,6 +451,42 @@ fn test_numbers() {
 }
 
 #[test]
+fn test_booleans() {
+    // YAML 1.1 booleans: https://yaml.org/type/bool.html
+    let cases = [
+        ("y", true),
+        ("Y", true),
+        ("yes", true),
+        ("Yes", true),
+        ("YES", true),
+        ("true", true),
+        ("True", true),
+        ("TRUE", true),
+        ("on", true),
+        ("On", true),
+        ("ON", true),
+        ("n", false),
+        ("N", false),
+        ("no", false),
+        ("No", false),
+        ("NO", false),
+        ("false", false),
+        ("False", false),
+        ("FALSE", false),
+        ("off", false),
+        ("Off", false),
+        ("OFF", false),
+    ];
+    for (yaml, expected) in cases {
+        let value = serde_yaml_ng::from_str::<Value>(yaml).unwrap();
+        match value {
+            Value::Bool(bool) => assert_eq!(bool, expected),
+            _ => panic!("expected boolean, input={:?}, result={:?}", yaml, value),
+        };
+    }
+}
+
+#[test]
 fn test_nan() {
     // There is no negative NaN in YAML.
     assert!(serde_yaml_ng::from_str::<f32>(".nan")
@@ -637,22 +673,6 @@ fn test_tag_resolution() {
         - false
         - False
         - FALSE
-        - y
-        - Y
-        - yes
-        - Yes
-        - YES
-        - n
-        - N
-        - no
-        - No
-        - NO
-        - on
-        - On
-        - ON
-        - off
-        - Off
-        - OFF
     "};
 
     let expected = vec![
@@ -667,22 +687,6 @@ fn test_tag_resolution() {
         Value::Bool(false),
         Value::Bool(false),
         Value::Bool(false),
-        Value::String("y".to_owned()),
-        Value::String("Y".to_owned()),
-        Value::String("yes".to_owned()),
-        Value::String("Yes".to_owned()),
-        Value::String("YES".to_owned()),
-        Value::String("n".to_owned()),
-        Value::String("N".to_owned()),
-        Value::String("no".to_owned()),
-        Value::String("No".to_owned()),
-        Value::String("NO".to_owned()),
-        Value::String("on".to_owned()),
-        Value::String("On".to_owned()),
-        Value::String("ON".to_owned()),
-        Value::String("off".to_owned()),
-        Value::String("Off".to_owned()),
-        Value::String("OFF".to_owned()),
     ];
 
     test_de(yaml, &expected);

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -195,7 +195,7 @@ fn test_map() {
     thing.insert("y".to_owned(), 2);
     let yaml = indoc! {"
         x: 1
-        y: 2
+        'y': 2
     "};
     test_serde(&thing, yaml);
 }
@@ -238,7 +238,7 @@ fn test_basic_struct() {
     };
     let yaml = indoc! {r#"
         x: -4
-        y: "hi\tquoted"
+        'y': "hi\tquoted"
         z: true
     "#};
     test_serde(&thing, yaml);


### PR DESCRIPTION
Added all the boolean representations from the YAML 1.1 specification.

Some tests had to be modified as `y` is interpreted as a boolean in mappings (rather than a string) if serde is not deserializing into a known struct.

Also created an additional test for the boolean value parsing.